### PR TITLE
Update React to 0.13.1

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -85,6 +85,38 @@
     },
     "connect-route": {
       "version": "0.1.4"
+    },
+    "react": {
+      "version": "0.13.1",
+      "dependencies": {
+        "envify": {
+          "version": "3.4.0",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7"
+            },
+            "jstransform": {
+              "version": "10.1.0",
+              "dependencies": {
+                "base62": {
+                  "version": "0.1.1"
+                },
+                "esprima-fb": {
+                  "version": "13001.1001.0-dev-harmony-fb"
+                },
+                "source-map": {
+                  "version": "0.1.31",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/.npm/plugin/compileJSX/npm-shrinkwrap.json
+++ b/.npm/plugin/compileJSX/npm-shrinkwrap.json
@@ -1,50 +1,55 @@
 {
   "dependencies": {
     "react-tools": {
-      "version": "0.11.1",
+      "version": "0.13.1",
       "dependencies": {
         "commoner": {
-          "version": "0.9.8",
+          "version": "0.10.1",
           "dependencies": {
             "q": {
-              "version": "1.0.1"
+              "version": "1.1.2"
             },
             "recast": {
-              "version": "0.7.0",
+              "version": "0.9.18",
               "dependencies": {
                 "esprima-fb": {
-                  "version": "5001.1.0-dev-harmony-fb"
+                  "version": "10001.1.0-dev-harmony-fb"
                 },
                 "source-map": {
-                  "version": "0.1.32",
+                  "version": "0.1.43",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0"
                     }
                   }
                 },
-                "cls": {
-                  "version": "0.1.5"
-                },
                 "ast-types": {
-                  "version": "0.4.9"
+                  "version": "0.6.16"
                 }
               }
             },
             "commander": {
-              "version": "2.2.0"
+              "version": "2.5.1"
             },
             "graceful-fs": {
-              "version": "2.0.3"
+              "version": "3.0.6"
             },
             "glob": {
-              "version": "3.2.11",
+              "version": "4.2.2",
               "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
                 "inherits": {
                   "version": "2.0.1"
                 },
                 "minimatch": {
-                  "version": "0.3.0",
+                  "version": "1.0.0",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0"
@@ -53,65 +58,44 @@
                       "version": "1.0.0"
                     }
                   }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.3.5"
-            },
-            "private": {
-              "version": "0.1.5"
-            },
-            "install": {
-              "version": "0.1.7",
-              "dependencies": {
-                "whiskey": {
-                  "version": "0.6.13",
+                },
+                "once": {
+                  "version": "1.3.1",
                   "dependencies": {
-                    "sprintf": {
-                      "version": "0.1.4"
-                    },
-                    "async": {
-                      "version": "0.9.0"
-                    },
-                    "magic-templates": {
-                      "version": "0.1.1"
-                    },
-                    "rimraf": {
+                    "wrappy": {
                       "version": "1.0.1"
-                    },
-                    "terminal": {
-                      "version": "0.1.3"
-                    },
-                    "gex": {
-                      "version": "0.0.1"
-                    },
-                    "simplesets": {
-                      "version": "1.1.6"
-                    },
-                    "logmagic": {
-                      "version": "0.1.4"
-                    },
-                    "underscore": {
-                      "version": "1.7.0"
                     }
                   }
                 }
               }
             },
+            "mkdirp": {
+              "version": "0.5.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8"
+                }
+              }
+            },
+            "private": {
+              "version": "0.1.6"
+            },
+            "install": {
+              "version": "0.1.8"
+            },
             "iconv-lite": {
-              "version": "0.2.11"
+              "version": "0.4.7"
             }
           }
         },
-        "esprima-fb": {
-          "version": "4001.3001.0-dev-harmony-fb"
-        },
         "jstransform": {
-          "version": "6.1.0",
+          "version": "10.1.0",
           "dependencies": {
             "base62": {
               "version": "0.1.1"
+            },
+            "esprima-fb": {
+              "version": "13001.1001.0-dev-harmony-fb"
             },
             "source-map": {
               "version": "0.1.31",

--- a/package.js
+++ b/package.js
@@ -1,13 +1,14 @@
 Package.describe({
   name: 'mystor:routecore',
   summary: 'client and server side rendering/routing powered by React',
-  version: '0.1.5',
+  version: '0.2.0',
   git: 'https://github.com/mystor/meteor-routecore.git'
 });
 
 Npm.depends({
   'connect': '2.13.0',
-  'connect-route': '0.1.4'
+  'connect-route': '0.1.4',
+  'react': '0.13.1'
 });
 
 Package._transitional_registerBuildPlugin({
@@ -17,7 +18,7 @@ Package._transitional_registerBuildPlugin({
     'plugin/compile-jsx.js'
   ],
   npmDependencies: {
-    'react-tools': '0.11.1'
+    'react-tools': '0.13.1'
   }
 });
 
@@ -30,7 +31,7 @@ Package.on_use(function (api) {
   api.use('meteorhacks:fast-render@1.0.0', ['client', 'server']);
   api.use('iron:dynamic-template@0.3.0', 'client');
 
-  api.add_files('react-with-addons-0.11.1.js', ['client', 'server']);
+  api.add_files('react-with-addons-0.13.1.js', ['client', 'server']);
 
   api.add_files('routecore-common.js', ['client', 'server']);
   api.add_files('context-client.js', 'client');

--- a/routecore-client.js
+++ b/routecore-client.js
@@ -38,7 +38,7 @@ function _wrap (cb) {
       // Instead, you should use the RouteCore.ReactiveMixin mixin,
       // or create your React components with RouteCore.createClass()
       Deps.nonreactive(function() {
-        React.renderComponent(
+        React.render(
           component,
           document.getElementById('-routecore-react-root')
         );

--- a/routecore-server.js
+++ b/routecore-server.js
@@ -36,7 +36,7 @@ function _wrap (cb) {
           }
 
           // Render the html
-          res.bodyHtml = React.renderComponentToString(component);
+          res.bodyHtml = React.renderToString(component);
 
           // Save the query data
           // TODO: Make this merge with queryData potentially already in req


### PR DESCRIPTION
I updated the react library and patched the client and server to match the [react api changes](https://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html#renamed-apis).

As the `react-addons` [npm package is deprecated](https://www.npmjs.com/package/react-addons) the `react-with-addons.js` file was build using browserify: 

``` bash
browserify --standalone React .npm/package/node_modules/react/addons.js > react-with-addons-0.13.1.js
```

It seems to work well in my project but I recommend further testing
